### PR TITLE
[OTS-935] Add babel-transform-object-assign

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "plugins": ["transform-object-assign"]
 }

--- a/browser/opentok-acc-core.js
+++ b/browser/opentok-acc-core.js
@@ -3,7 +3,7 @@ function _classCallCheck(n,e){if(!(n instanceof e))throw new TypeError("Cannot c
 },{}],2:[function(require,module,exports){
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 /* global OT */
 
@@ -84,7 +84,7 @@ var ableToJoin = function ableToJoin() {
 var createPublisher = function createPublisher(publisherProperties) {
   return new Promise(function (resolve, reject) {
     // TODO: Handle adding 'name' option to props
-    var props = Object.assign({}, callProperties, publisherProperties);
+    var props = _extends({}, callProperties, publisherProperties);
     // TODO: Figure out how to handle common vs package-specific options
     // ^^^ This may already be available through package options
     var container = dom.element(streamContainers('publisher', 'camera'));
@@ -144,25 +144,23 @@ var subscribe = function subscribe(stream) {
       // Are we already subscribing to the stream?
       resolve();
     } else {
-      (function () {
-        // No videoType indicates SIP https://tokbox.com/developer/guides/sip/
-        var type = pathOr('sip', 'videoType', stream);
-        var connectionData = JSON.parse(path(['connection', 'data'], stream) || null);
-        var container = dom.query(streamContainers('subscriber', type, connectionData, streamId));
-        var options = type === 'camera' ? callProperties : screenProperties;
-        var subscriber = session.subscribe(stream, container, options, function (error) {
-          if (error) {
-            logAnalytics(logAction.subscribe, logVariation.fail);
-            reject(error);
-          } else {
-            state.addSubscriber(subscriber);
-            triggerEvent('subscribeTo' + properCase(type), Object.assign({}, { subscriber: subscriber }, state.all()));
-            type === 'screen' && triggerEvent('startViewingSharedScreen', subscriber); // Legacy event
-            logAnalytics(logAction.subscribe, logVariation.success);
-            resolve();
-          }
-        });
-      })();
+      // No videoType indicates SIP https://tokbox.com/developer/guides/sip/
+      var type = pathOr('sip', 'videoType', stream);
+      var connectionData = JSON.parse(path(['connection', 'data'], stream) || null);
+      var container = dom.query(streamContainers('subscriber', type, connectionData, streamId));
+      var options = type === 'camera' ? callProperties : screenProperties;
+      var subscriber = session.subscribe(stream, container, options, function (error) {
+        if (error) {
+          logAnalytics(logAction.subscribe, logVariation.fail);
+          reject(error);
+        } else {
+          state.addSubscriber(subscriber);
+          triggerEvent('subscribeTo' + properCase(type), _extends({}, { subscriber: subscriber }, state.all()));
+          type === 'screen' && triggerEvent('startViewingSharedScreen', subscriber); // Legacy event
+          logAnalytics(logAction.subscribe, logVariation.success);
+          resolve();
+        }
+      });
     }
   });
 };
@@ -201,7 +199,7 @@ var validateOptions = function validateOptions(options) {
   connectionLimit = options.connectionLimit || null;
   autoSubscribe = options.hasOwnProperty('autoSubscribe') ? options.autoSubscribe : true;
 
-  screenProperties = options.screenProperties || Object.assign({}, defaultCallProperties, { videoSource: 'window' });
+  screenProperties = options.screenProperties || _extends({}, defaultCallProperties, { videoSource: 'window' });
 };
 
 /**
@@ -268,23 +266,17 @@ var startCall = function startCall(publisherProperties) {
       // Get an array of initial subscription promises
       var initialSubscriptions = function initialSubscriptions() {
         if (autoSubscribe) {
-          var _ret2 = function () {
-            var streams = state.getStreams();
-            return {
-              v: Object.keys(streams).map(function (id) {
-                return subscribe(streams[id]);
-              })
-            };
-          }();
-
-          if ((typeof _ret2 === 'undefined' ? 'undefined' : _typeof(_ret2)) === "object") return _ret2.v;
+          var streams = state.getStreams();
+          return Object.keys(streams).map(function (id) {
+            return subscribe(streams[id]);
+          });
         }
         return [Promise.resolve()];
       };
 
       // Handle success
       var onSubscribeToAll = function onSubscribeToAll() {
-        var pubSubData = Object.assign({}, state.getPubSub(), { publisher: publisher });
+        var pubSubData = _extends({}, state.getPubSub(), { publisher: publisher });
         triggerEvent('startCall', pubSubData);
         active = true;
         resolve(pubSubData);
@@ -294,7 +286,7 @@ var startCall = function startCall(publisherProperties) {
       var onError = function onError(reason) {
         message('Failed to subscribe to all existing streams: ' + reason);
         // We do not reject here in case we still successfully publish to the session
-        resolve(Object.assign({}, state.getPubSub(), { publisher: publisher }));
+        resolve(_extends({}, state.getPubSub(), { publisher: publisher }));
       };
 
       Promise.all(initialSubscriptions()).then(onSubscribeToAll).catch(onError);
@@ -387,6 +379,8 @@ module.exports = {
 },{"./errors":4,"./logging":6,"./state":10,"./util":11}],3:[function(require,module,exports){
 (function (global){
 'use strict';
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 var _arguments = arguments;
 
@@ -596,7 +590,7 @@ var createEventListeners = function createEventListeners(session, options) {
 
   on('startScreenSharing', function (publisher) {
     internalState.addPublisher('screen', publisher);
-    triggerEvent('startScreenShare', Object.assign({}, { publisher: publisher }, internalState.getPubSub()));
+    triggerEvent('startScreenShare', _extends({}, { publisher: publisher }, internalState.getPubSub()));
     if (internalAnnotation) {
       annotation.start(getSession()).then(function () {
         var absoluteParent = dom.query(path('annotation.absoluteParent.publisher', options));
@@ -628,15 +622,13 @@ var linkAnnotation = function linkAnnotation(pubSub, annotationContainer, extern
   });
 
   if (externalWindow) {
-    (function () {
-      // Add subscribers to the external window
-      var streams = internalState.getStreams();
-      var cameraStreams = Object.keys(streams).reduce(function (acc, streamId) {
-        var stream = streams[streamId];
-        return stream.videoType === 'camera' ? acc.concat(stream) : acc;
-      }, []);
-      cameraStreams.forEach(annotation.addSubscriberToExternalWindow);
-    })();
+    // Add subscribers to the external window
+    var streams = internalState.getStreams();
+    var cameraStreams = Object.keys(streams).reduce(function (acc, streamId) {
+      var stream = streams[streamId];
+      return stream.videoType === 'camera' ? acc.concat(stream) : acc;
+    }, []);
+    cameraStreams.forEach(annotation.addSubscriberToExternalWindow);
   }
 };
 
@@ -756,7 +748,7 @@ var initPackages = function initPackages() {
       /* beautify ignore:start */
       case 'communication':
         {
-          return Object.assign({}, baseOptions, options.communication);
+          return _extends({}, baseOptions, options.communication);
         }
       case 'textChat':
         {
@@ -766,20 +758,20 @@ var initPackages = function initPackages() {
             sender: { alias: path('textChat.name', options) },
             alwaysOpen: path('textChat.alwaysOpen', options)
           };
-          return Object.assign({}, baseOptions, textChatOptions);
+          return _extends({}, baseOptions, textChatOptions);
         }
       case 'screenSharing':
         {
           var screenSharingContainer = { screenSharingContainer: streamContainers };
-          return Object.assign({}, baseOptions, screenSharingContainer, options.screenSharing);
+          return _extends({}, baseOptions, screenSharingContainer, options.screenSharing);
         }
       case 'annotation':
         {
-          return Object.assign({}, baseOptions, options.annotation);
+          return _extends({}, baseOptions, options.annotation);
         }
       case 'archiving':
         {
-          return Object.assign({}, baseOptions, options.archiving);
+          return _extends({}, baseOptions, options.archiving);
         }
       default:
         return {};
@@ -926,7 +918,7 @@ var signal = function signal(type, data, to) {
   return new Promise(function (resolve, reject) {
     logAnalytics(logAction.signal, logVariation.attempt);
     var session = getSession();
-    var signalObj = Object.assign({}, type ? { type: type } : null, data ? { data: JSON.stringify(data) } : null, to ? { to: to } : null // eslint-disable-line comma-dangle
+    var signalObj = _extends({}, type ? { type: type } : null, data ? { data: JSON.stringify(data) } : null, to ? { to: to } : null // eslint-disable-line comma-dangle
     );
     session.signal(signalObj, function (error) {
       if (error) {
@@ -1705,6 +1697,8 @@ module.exports = OpenTokSDK;
 },{"./errors":7,"./state":9}],9:[function(require,module,exports){
 "use strict";
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -1889,7 +1883,7 @@ var State = function () {
       var streams = this.streams,
           streamMap = this.streamMap;
 
-      return Object.assign({}, this.getPubSub(), { streams: streams, streamMap: streamMap });
+      return _extends({}, this.getPubSub(), { streams: streams, streamMap: streamMap });
     }
   }]);
 
@@ -1900,6 +1894,8 @@ module.exports = State;
 
 },{}],10:[function(require,module,exports){
 'use strict';
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 /**
  * Internal variables
@@ -1978,7 +1974,7 @@ var getPubSub = function getPubSub() {
  * @return {Object}
  */
 var all = function all() {
-  return Object.assign({}, { streams: streams, streamMap: streamMap }, getPubSub());
+  return _extends({}, { streams: streams, streamMap: streamMap }, getPubSub());
 };
 
 /**

--- a/dist/communication.js
+++ b/dist/communication.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 /* global OT */
 
@@ -25,13 +25,13 @@ var _require3 = require('./logging'),
 /** Module variables */
 
 
-var session = undefined;
-var accPack = undefined;
-var callProperties = undefined;
-var screenProperties = undefined;
-var streamContainers = undefined;
-var autoSubscribe = undefined;
-var connectionLimit = undefined;
+var session = void 0;
+var accPack = void 0;
+var callProperties = void 0;
+var screenProperties = void 0;
+var streamContainers = void 0;
+var autoSubscribe = void 0;
+var connectionLimit = void 0;
 var active = false;
 
 /**
@@ -81,7 +81,7 @@ var ableToJoin = function ableToJoin() {
 var createPublisher = function createPublisher(publisherProperties) {
   return new Promise(function (resolve, reject) {
     // TODO: Handle adding 'name' option to props
-    var props = Object.assign({}, callProperties, publisherProperties);
+    var props = _extends({}, callProperties, publisherProperties);
     // TODO: Figure out how to handle common vs package-specific options
     // ^^^ This may already be available through package options
     var container = dom.element(streamContainers('publisher', 'camera'));
@@ -141,25 +141,23 @@ var subscribe = function subscribe(stream) {
       // Are we already subscribing to the stream?
       resolve();
     } else {
-      (function () {
-        // No videoType indicates SIP https://tokbox.com/developer/guides/sip/
-        var type = pathOr('sip', 'videoType', stream);
-        var connectionData = JSON.parse(path(['connection', 'data'], stream) || null);
-        var container = dom.query(streamContainers('subscriber', type, connectionData, streamId));
-        var options = type === 'camera' ? callProperties : screenProperties;
-        var subscriber = session.subscribe(stream, container, options, function (error) {
-          if (error) {
-            logAnalytics(logAction.subscribe, logVariation.fail);
-            reject(error);
-          } else {
-            state.addSubscriber(subscriber);
-            triggerEvent('subscribeTo' + properCase(type), Object.assign({}, { subscriber: subscriber }, state.all()));
-            type === 'screen' && triggerEvent('startViewingSharedScreen', subscriber); // Legacy event
-            logAnalytics(logAction.subscribe, logVariation.success);
-            resolve();
-          }
-        });
-      })();
+      // No videoType indicates SIP https://tokbox.com/developer/guides/sip/
+      var type = pathOr('sip', 'videoType', stream);
+      var connectionData = JSON.parse(path(['connection', 'data'], stream) || null);
+      var container = dom.query(streamContainers('subscriber', type, connectionData, streamId));
+      var options = type === 'camera' ? callProperties : screenProperties;
+      var subscriber = session.subscribe(stream, container, options, function (error) {
+        if (error) {
+          logAnalytics(logAction.subscribe, logVariation.fail);
+          reject(error);
+        } else {
+          state.addSubscriber(subscriber);
+          triggerEvent('subscribeTo' + properCase(type), _extends({}, { subscriber: subscriber }, state.all()));
+          type === 'screen' && triggerEvent('startViewingSharedScreen', subscriber); // Legacy event
+          logAnalytics(logAction.subscribe, logVariation.success);
+          resolve();
+        }
+      });
     }
   });
 };
@@ -198,7 +196,7 @@ var validateOptions = function validateOptions(options) {
   connectionLimit = options.connectionLimit || null;
   autoSubscribe = options.hasOwnProperty('autoSubscribe') ? options.autoSubscribe : true;
 
-  screenProperties = options.screenProperties || Object.assign({}, defaultCallProperties, { videoSource: 'window' });
+  screenProperties = options.screenProperties || _extends({}, defaultCallProperties, { videoSource: 'window' });
 };
 
 /**
@@ -265,23 +263,17 @@ var startCall = function startCall(publisherProperties) {
       // Get an array of initial subscription promises
       var initialSubscriptions = function initialSubscriptions() {
         if (autoSubscribe) {
-          var _ret2 = function () {
-            var streams = state.getStreams();
-            return {
-              v: Object.keys(streams).map(function (id) {
-                return subscribe(streams[id]);
-              })
-            };
-          }();
-
-          if ((typeof _ret2 === 'undefined' ? 'undefined' : _typeof(_ret2)) === "object") return _ret2.v;
+          var streams = state.getStreams();
+          return Object.keys(streams).map(function (id) {
+            return subscribe(streams[id]);
+          });
         }
         return [Promise.resolve()];
       };
 
       // Handle success
       var onSubscribeToAll = function onSubscribeToAll() {
-        var pubSubData = Object.assign({}, state.getPubSub(), { publisher: publisher });
+        var pubSubData = _extends({}, state.getPubSub(), { publisher: publisher });
         triggerEvent('startCall', pubSubData);
         active = true;
         resolve(pubSubData);
@@ -291,7 +283,7 @@ var startCall = function startCall(publisherProperties) {
       var onError = function onError(reason) {
         message('Failed to subscribe to all existing streams: ' + reason);
         // We do not reject here in case we still successfully publish to the session
-        resolve(Object.assign({}, state.getPubSub(), { publisher: publisher }));
+        resolve(_extends({}, state.getPubSub(), { publisher: publisher }));
       };
 
       Promise.all(initialSubscriptions()).then(onSubscribeToAll).catch(onError);

--- a/dist/core.js
+++ b/dist/core.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _arguments = arguments;
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 /* global OT */
 /**
@@ -39,10 +41,10 @@ var dom = util.dom,
  * Individual Accelerator Packs
  */
 
-var textChat = undefined; // eslint-disable-line no-unused-vars
-var screenSharing = undefined; // eslint-disable-line no-unused-vars
-var annotation = undefined;
-var archiving = undefined; // eslint-disable-line no-unused-vars
+var textChat = void 0; // eslint-disable-line no-unused-vars
+var screenSharing = void 0; // eslint-disable-line no-unused-vars
+var annotation = void 0;
+var archiving = void 0; // eslint-disable-line no-unused-vars
 
 /**
  * Get access to an accelerator pack
@@ -99,9 +101,9 @@ var on = function on(event, callback) {
     message(event + ' is not a registered event.');
     // logAnalytics(logAction.on, logVariation.fail);
   } else {
-      eventCallbacks.add(callback);
-      // logAnalytics(logAction.on, logVariation.success);
-    }
+    eventCallbacks.add(callback);
+    // logAnalytics(logAction.on, logVariation.success);
+  }
 };
 
 /**
@@ -208,7 +210,7 @@ var createEventListeners = function createEventListeners(session, options) {
 
   on('startScreenSharing', function (publisher) {
     internalState.addPublisher('screen', publisher);
-    triggerEvent('startScreenShare', Object.assign({}, { publisher: publisher }, internalState.getPubSub()));
+    triggerEvent('startScreenShare', _extends({}, { publisher: publisher }, internalState.getPubSub()));
     if (internalAnnotation) {
       annotation.start(getSession()).then(function () {
         var absoluteParent = dom.query(path('annotation.absoluteParent.publisher', options));
@@ -240,15 +242,13 @@ var linkAnnotation = function linkAnnotation(pubSub, annotationContainer, extern
   });
 
   if (externalWindow) {
-    (function () {
-      // Add subscribers to the external window
-      var streams = internalState.getStreams();
-      var cameraStreams = Object.keys(streams).reduce(function (acc, streamId) {
-        var stream = streams[streamId];
-        return stream.videoType === 'camera' ? acc.concat(stream) : acc;
-      }, []);
-      cameraStreams.forEach(annotation.addSubscriberToExternalWindow);
-    })();
+    // Add subscribers to the external window
+    var streams = internalState.getStreams();
+    var cameraStreams = Object.keys(streams).reduce(function (acc, streamId) {
+      var stream = streams[streamId];
+      return stream.videoType === 'camera' ? acc.concat(stream) : acc;
+    }, []);
+    cameraStreams.forEach(annotation.addSubscriberToExternalWindow);
   }
 };
 
@@ -266,7 +266,7 @@ var initPackages = function initPackages() {
    * @returns {Object}
    */
   var optionalRequire = function optionalRequire(packageName, globalName) {
-    var result = undefined;
+    var result = void 0;
     /* eslint-disable global-require, import/no-extraneous-dependencies, import/no-unresolved */
     try {
       switch (packageName) {
@@ -368,7 +368,7 @@ var initPackages = function initPackages() {
       /* beautify ignore:start */
       case 'communication':
         {
-          return Object.assign({}, baseOptions, options.communication);
+          return _extends({}, baseOptions, options.communication);
         }
       case 'textChat':
         {
@@ -378,20 +378,20 @@ var initPackages = function initPackages() {
             sender: { alias: path('textChat.name', options) },
             alwaysOpen: path('textChat.alwaysOpen', options)
           };
-          return Object.assign({}, baseOptions, textChatOptions);
+          return _extends({}, baseOptions, textChatOptions);
         }
       case 'screenSharing':
         {
           var screenSharingContainer = { screenSharingContainer: streamContainers };
-          return Object.assign({}, baseOptions, screenSharingContainer, options.screenSharing);
+          return _extends({}, baseOptions, screenSharingContainer, options.screenSharing);
         }
       case 'annotation':
         {
-          return Object.assign({}, baseOptions, options.annotation);
+          return _extends({}, baseOptions, options.annotation);
         }
       case 'archiving':
         {
-          return Object.assign({}, baseOptions, options.archiving);
+          return _extends({}, baseOptions, options.archiving);
         }
       default:
         return {};
@@ -538,7 +538,7 @@ var signal = function signal(type, data, to) {
   return new Promise(function (resolve, reject) {
     logAnalytics(logAction.signal, logVariation.attempt);
     var session = getSession();
-    var signalObj = Object.assign({}, type ? { type: type } : null, data ? { data: JSON.stringify(data) } : null, to ? { to: to } : null // eslint-disable-line comma-dangle
+    var signalObj = _extends({}, type ? { type: type } : null, data ? { data: JSON.stringify(data) } : null, to ? { to: to } : null // eslint-disable-line comma-dangle
     );
     session.signal(signalObj, function (error) {
       if (error) {

--- a/dist/errors.js
+++ b/dist/errors.js
@@ -7,7 +7,6 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 /** Errors */
-
 var CoreError = function (_Error) {
   _inherits(CoreError, _Error);
 

--- a/dist/sdk-wrapper/errors.js
+++ b/dist/sdk-wrapper/errors.js
@@ -7,7 +7,6 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 /** Errors */
-
 var SDKError = function (_Error) {
   _inherits(SDKError, _Error);
 

--- a/dist/sdk-wrapper/sdkWrapper.js
+++ b/dist/sdk-wrapper/sdkWrapper.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -107,7 +107,6 @@ var OpenTokSDK = function () {
    * @param {String} credentials.sessionId
    * @param {String} credentials.token
    */
-
   function OpenTokSDK(credentials) {
     _classCallCheck(this, OpenTokSDK);
 

--- a/dist/sdk-wrapper/state.js
+++ b/dist/sdk-wrapper/state.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -184,7 +186,7 @@ var State = function () {
       var streams = this.streams,
           streamMap = this.streamMap;
 
-      return Object.assign({}, this.getPubSub(), { streams: streams, streamMap: streamMap });
+      return _extends({}, this.getPubSub(), { streams: streams, streamMap: streamMap });
     }
   }]);
 

--- a/dist/state.js
+++ b/dist/state.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 /**
  * Internal variables
  */
@@ -77,7 +79,7 @@ var getPubSub = function getPubSub() {
  * @return {Object}
  */
 var all = function all() {
-  return Object.assign({}, { streams: streams, streamMap: streamMap }, getPubSub());
+  return _extends({}, { streams: streams, streamMap: streamMap }, getPubSub());
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-accelerator-core",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Opentok Accelerator Core",
   "repository": "https://github.com/opentok/accelerator-core-js",
   "main": "dist/core.js",
@@ -23,6 +23,7 @@
   "author": "adrice727@gmail.com",
   "license": "MIT",
   "devDependencies": {
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.16.0",
     "babelify": "^7.3.0",
     "browserify": "^13.1.1",

--- a/react-sample-app/src/ot-core/communication.js
+++ b/react-sample-app/src/ot-core/communication.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 /* global OT */
 
@@ -25,13 +25,13 @@ var _require3 = require('./logging'),
 /** Module variables */
 
 
-var session = undefined;
-var accPack = undefined;
-var callProperties = undefined;
-var screenProperties = undefined;
-var streamContainers = undefined;
-var autoSubscribe = undefined;
-var connectionLimit = undefined;
+var session = void 0;
+var accPack = void 0;
+var callProperties = void 0;
+var screenProperties = void 0;
+var streamContainers = void 0;
+var autoSubscribe = void 0;
+var connectionLimit = void 0;
 var active = false;
 
 /**
@@ -81,7 +81,7 @@ var ableToJoin = function ableToJoin() {
 var createPublisher = function createPublisher(publisherProperties) {
   return new Promise(function (resolve, reject) {
     // TODO: Handle adding 'name' option to props
-    var props = Object.assign({}, callProperties, publisherProperties);
+    var props = _extends({}, callProperties, publisherProperties);
     // TODO: Figure out how to handle common vs package-specific options
     // ^^^ This may already be available through package options
     var container = dom.element(streamContainers('publisher', 'camera'));
@@ -141,25 +141,23 @@ var subscribe = function subscribe(stream) {
       // Are we already subscribing to the stream?
       resolve();
     } else {
-      (function () {
-        // No videoType indicates SIP https://tokbox.com/developer/guides/sip/
-        var type = pathOr('sip', 'videoType', stream);
-        var connectionData = JSON.parse(path(['connection', 'data'], stream) || null);
-        var container = dom.query(streamContainers('subscriber', type, connectionData, streamId));
-        var options = type === 'camera' ? callProperties : screenProperties;
-        var subscriber = session.subscribe(stream, container, options, function (error) {
-          if (error) {
-            logAnalytics(logAction.subscribe, logVariation.fail);
-            reject(error);
-          } else {
-            state.addSubscriber(subscriber);
-            triggerEvent('subscribeTo' + properCase(type), Object.assign({}, { subscriber: subscriber }, state.all()));
-            type === 'screen' && triggerEvent('startViewingSharedScreen', subscriber); // Legacy event
-            logAnalytics(logAction.subscribe, logVariation.success);
-            resolve();
-          }
-        });
-      })();
+      // No videoType indicates SIP https://tokbox.com/developer/guides/sip/
+      var type = pathOr('sip', 'videoType', stream);
+      var connectionData = JSON.parse(path(['connection', 'data'], stream) || null);
+      var container = dom.query(streamContainers('subscriber', type, connectionData, streamId));
+      var options = type === 'camera' ? callProperties : screenProperties;
+      var subscriber = session.subscribe(stream, container, options, function (error) {
+        if (error) {
+          logAnalytics(logAction.subscribe, logVariation.fail);
+          reject(error);
+        } else {
+          state.addSubscriber(subscriber);
+          triggerEvent('subscribeTo' + properCase(type), _extends({}, { subscriber: subscriber }, state.all()));
+          type === 'screen' && triggerEvent('startViewingSharedScreen', subscriber); // Legacy event
+          logAnalytics(logAction.subscribe, logVariation.success);
+          resolve();
+        }
+      });
     }
   });
 };
@@ -198,7 +196,7 @@ var validateOptions = function validateOptions(options) {
   connectionLimit = options.connectionLimit || null;
   autoSubscribe = options.hasOwnProperty('autoSubscribe') ? options.autoSubscribe : true;
 
-  screenProperties = options.screenProperties || Object.assign({}, defaultCallProperties, { videoSource: 'window' });
+  screenProperties = options.screenProperties || _extends({}, defaultCallProperties, { videoSource: 'window' });
 };
 
 /**
@@ -265,23 +263,17 @@ var startCall = function startCall(publisherProperties) {
       // Get an array of initial subscription promises
       var initialSubscriptions = function initialSubscriptions() {
         if (autoSubscribe) {
-          var _ret2 = function () {
-            var streams = state.getStreams();
-            return {
-              v: Object.keys(streams).map(function (id) {
-                return subscribe(streams[id]);
-              })
-            };
-          }();
-
-          if ((typeof _ret2 === 'undefined' ? 'undefined' : _typeof(_ret2)) === "object") return _ret2.v;
+          var streams = state.getStreams();
+          return Object.keys(streams).map(function (id) {
+            return subscribe(streams[id]);
+          });
         }
         return [Promise.resolve()];
       };
 
       // Handle success
       var onSubscribeToAll = function onSubscribeToAll() {
-        var pubSubData = Object.assign({}, state.getPubSub(), { publisher: publisher });
+        var pubSubData = _extends({}, state.getPubSub(), { publisher: publisher });
         triggerEvent('startCall', pubSubData);
         active = true;
         resolve(pubSubData);
@@ -291,7 +283,7 @@ var startCall = function startCall(publisherProperties) {
       var onError = function onError(reason) {
         message('Failed to subscribe to all existing streams: ' + reason);
         // We do not reject here in case we still successfully publish to the session
-        resolve(Object.assign({}, state.getPubSub(), { publisher: publisher }));
+        resolve(_extends({}, state.getPubSub(), { publisher: publisher }));
       };
 
       Promise.all(initialSubscriptions()).then(onSubscribeToAll).catch(onError);

--- a/react-sample-app/src/ot-core/core.js
+++ b/react-sample-app/src/ot-core/core.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _arguments = arguments;
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 /* global OT */
 /**
@@ -39,10 +41,10 @@ var dom = util.dom,
  * Individual Accelerator Packs
  */
 
-var textChat = undefined; // eslint-disable-line no-unused-vars
-var screenSharing = undefined; // eslint-disable-line no-unused-vars
-var annotation = undefined;
-var archiving = undefined; // eslint-disable-line no-unused-vars
+var textChat = void 0; // eslint-disable-line no-unused-vars
+var screenSharing = void 0; // eslint-disable-line no-unused-vars
+var annotation = void 0;
+var archiving = void 0; // eslint-disable-line no-unused-vars
 
 /**
  * Get access to an accelerator pack
@@ -99,9 +101,9 @@ var on = function on(event, callback) {
     message(event + ' is not a registered event.');
     // logAnalytics(logAction.on, logVariation.fail);
   } else {
-      eventCallbacks.add(callback);
-      // logAnalytics(logAction.on, logVariation.success);
-    }
+    eventCallbacks.add(callback);
+    // logAnalytics(logAction.on, logVariation.success);
+  }
 };
 
 /**
@@ -208,7 +210,7 @@ var createEventListeners = function createEventListeners(session, options) {
 
   on('startScreenSharing', function (publisher) {
     internalState.addPublisher('screen', publisher);
-    triggerEvent('startScreenShare', Object.assign({}, { publisher: publisher }, internalState.getPubSub()));
+    triggerEvent('startScreenShare', _extends({}, { publisher: publisher }, internalState.getPubSub()));
     if (internalAnnotation) {
       annotation.start(getSession()).then(function () {
         var absoluteParent = dom.query(path('annotation.absoluteParent.publisher', options));
@@ -240,15 +242,13 @@ var linkAnnotation = function linkAnnotation(pubSub, annotationContainer, extern
   });
 
   if (externalWindow) {
-    (function () {
-      // Add subscribers to the external window
-      var streams = internalState.getStreams();
-      var cameraStreams = Object.keys(streams).reduce(function (acc, streamId) {
-        var stream = streams[streamId];
-        return stream.videoType === 'camera' ? acc.concat(stream) : acc;
-      }, []);
-      cameraStreams.forEach(annotation.addSubscriberToExternalWindow);
-    })();
+    // Add subscribers to the external window
+    var streams = internalState.getStreams();
+    var cameraStreams = Object.keys(streams).reduce(function (acc, streamId) {
+      var stream = streams[streamId];
+      return stream.videoType === 'camera' ? acc.concat(stream) : acc;
+    }, []);
+    cameraStreams.forEach(annotation.addSubscriberToExternalWindow);
   }
 };
 
@@ -266,7 +266,7 @@ var initPackages = function initPackages() {
    * @returns {Object}
    */
   var optionalRequire = function optionalRequire(packageName, globalName) {
-    var result = undefined;
+    var result = void 0;
     /* eslint-disable global-require, import/no-extraneous-dependencies, import/no-unresolved */
     try {
       switch (packageName) {
@@ -368,7 +368,7 @@ var initPackages = function initPackages() {
       /* beautify ignore:start */
       case 'communication':
         {
-          return Object.assign({}, baseOptions, options.communication);
+          return _extends({}, baseOptions, options.communication);
         }
       case 'textChat':
         {
@@ -378,20 +378,20 @@ var initPackages = function initPackages() {
             sender: { alias: path('textChat.name', options) },
             alwaysOpen: path('textChat.alwaysOpen', options)
           };
-          return Object.assign({}, baseOptions, textChatOptions);
+          return _extends({}, baseOptions, textChatOptions);
         }
       case 'screenSharing':
         {
           var screenSharingContainer = { screenSharingContainer: streamContainers };
-          return Object.assign({}, baseOptions, screenSharingContainer, options.screenSharing);
+          return _extends({}, baseOptions, screenSharingContainer, options.screenSharing);
         }
       case 'annotation':
         {
-          return Object.assign({}, baseOptions, options.annotation);
+          return _extends({}, baseOptions, options.annotation);
         }
       case 'archiving':
         {
-          return Object.assign({}, baseOptions, options.archiving);
+          return _extends({}, baseOptions, options.archiving);
         }
       default:
         return {};
@@ -538,7 +538,7 @@ var signal = function signal(type, data, to) {
   return new Promise(function (resolve, reject) {
     logAnalytics(logAction.signal, logVariation.attempt);
     var session = getSession();
-    var signalObj = Object.assign({}, type ? { type: type } : null, data ? { data: JSON.stringify(data) } : null, to ? { to: to } : null // eslint-disable-line comma-dangle
+    var signalObj = _extends({}, type ? { type: type } : null, data ? { data: JSON.stringify(data) } : null, to ? { to: to } : null // eslint-disable-line comma-dangle
     );
     session.signal(signalObj, function (error) {
       if (error) {

--- a/react-sample-app/src/ot-core/errors.js
+++ b/react-sample-app/src/ot-core/errors.js
@@ -7,7 +7,6 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 /** Errors */
-
 var CoreError = function (_Error) {
   _inherits(CoreError, _Error);
 

--- a/react-sample-app/src/ot-core/sdk-wrapper/errors.js
+++ b/react-sample-app/src/ot-core/sdk-wrapper/errors.js
@@ -7,7 +7,6 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 /** Errors */
-
 var SDKError = function (_Error) {
   _inherits(SDKError, _Error);
 

--- a/react-sample-app/src/ot-core/sdk-wrapper/sdkWrapper.js
+++ b/react-sample-app/src/ot-core/sdk-wrapper/sdkWrapper.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -107,7 +107,6 @@ var OpenTokSDK = function () {
    * @param {String} credentials.sessionId
    * @param {String} credentials.token
    */
-
   function OpenTokSDK(credentials) {
     _classCallCheck(this, OpenTokSDK);
 

--- a/react-sample-app/src/ot-core/sdk-wrapper/state.js
+++ b/react-sample-app/src/ot-core/sdk-wrapper/state.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -184,7 +186,7 @@ var State = function () {
       var streams = this.streams,
           streamMap = this.streamMap;
 
-      return Object.assign({}, this.getPubSub(), { streams: streams, streamMap: streamMap });
+      return _extends({}, this.getPubSub(), { streams: streams, streamMap: streamMap });
     }
   }]);
 

--- a/react-sample-app/src/ot-core/state.js
+++ b/react-sample-app/src/ot-core/state.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 /**
  * Internal variables
  */
@@ -77,7 +79,7 @@ var getPubSub = function getPubSub() {
  * @return {Object}
  */
 var all = function all() {
-  return Object.assign({}, { streams: streams, streamMap: streamMap }, getPubSub());
+  return _extends({}, { streams: streams, streamMap: streamMap }, getPubSub());
 };
 
 /**

--- a/sdk-wrapper-react-sample-app/src/ot-core/communication.js
+++ b/sdk-wrapper-react-sample-app/src/ot-core/communication.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 /* global OT */
 
@@ -25,13 +25,13 @@ var _require3 = require('./logging'),
 /** Module variables */
 
 
-var session = undefined;
-var accPack = undefined;
-var callProperties = undefined;
-var screenProperties = undefined;
-var streamContainers = undefined;
-var autoSubscribe = undefined;
-var connectionLimit = undefined;
+var session = void 0;
+var accPack = void 0;
+var callProperties = void 0;
+var screenProperties = void 0;
+var streamContainers = void 0;
+var autoSubscribe = void 0;
+var connectionLimit = void 0;
 var active = false;
 
 /**
@@ -81,7 +81,7 @@ var ableToJoin = function ableToJoin() {
 var createPublisher = function createPublisher(publisherProperties) {
   return new Promise(function (resolve, reject) {
     // TODO: Handle adding 'name' option to props
-    var props = Object.assign({}, callProperties, publisherProperties);
+    var props = _extends({}, callProperties, publisherProperties);
     // TODO: Figure out how to handle common vs package-specific options
     // ^^^ This may already be available through package options
     var container = dom.element(streamContainers('publisher', 'camera'));
@@ -141,25 +141,23 @@ var subscribe = function subscribe(stream) {
       // Are we already subscribing to the stream?
       resolve();
     } else {
-      (function () {
-        // No videoType indicates SIP https://tokbox.com/developer/guides/sip/
-        var type = pathOr('sip', 'videoType', stream);
-        var connectionData = JSON.parse(path(['connection', 'data'], stream) || null);
-        var container = dom.query(streamContainers('subscriber', type, connectionData, streamId));
-        var options = type === 'camera' ? callProperties : screenProperties;
-        var subscriber = session.subscribe(stream, container, options, function (error) {
-          if (error) {
-            logAnalytics(logAction.subscribe, logVariation.fail);
-            reject(error);
-          } else {
-            state.addSubscriber(subscriber);
-            triggerEvent('subscribeTo' + properCase(type), Object.assign({}, { subscriber: subscriber }, state.all()));
-            type === 'screen' && triggerEvent('startViewingSharedScreen', subscriber); // Legacy event
-            logAnalytics(logAction.subscribe, logVariation.success);
-            resolve();
-          }
-        });
-      })();
+      // No videoType indicates SIP https://tokbox.com/developer/guides/sip/
+      var type = pathOr('sip', 'videoType', stream);
+      var connectionData = JSON.parse(path(['connection', 'data'], stream) || null);
+      var container = dom.query(streamContainers('subscriber', type, connectionData, streamId));
+      var options = type === 'camera' ? callProperties : screenProperties;
+      var subscriber = session.subscribe(stream, container, options, function (error) {
+        if (error) {
+          logAnalytics(logAction.subscribe, logVariation.fail);
+          reject(error);
+        } else {
+          state.addSubscriber(subscriber);
+          triggerEvent('subscribeTo' + properCase(type), _extends({}, { subscriber: subscriber }, state.all()));
+          type === 'screen' && triggerEvent('startViewingSharedScreen', subscriber); // Legacy event
+          logAnalytics(logAction.subscribe, logVariation.success);
+          resolve();
+        }
+      });
     }
   });
 };
@@ -198,7 +196,7 @@ var validateOptions = function validateOptions(options) {
   connectionLimit = options.connectionLimit || null;
   autoSubscribe = options.hasOwnProperty('autoSubscribe') ? options.autoSubscribe : true;
 
-  screenProperties = options.screenProperties || Object.assign({}, defaultCallProperties, { videoSource: 'window' });
+  screenProperties = options.screenProperties || _extends({}, defaultCallProperties, { videoSource: 'window' });
 };
 
 /**
@@ -265,23 +263,17 @@ var startCall = function startCall(publisherProperties) {
       // Get an array of initial subscription promises
       var initialSubscriptions = function initialSubscriptions() {
         if (autoSubscribe) {
-          var _ret2 = function () {
-            var streams = state.getStreams();
-            return {
-              v: Object.keys(streams).map(function (id) {
-                return subscribe(streams[id]);
-              })
-            };
-          }();
-
-          if ((typeof _ret2 === 'undefined' ? 'undefined' : _typeof(_ret2)) === "object") return _ret2.v;
+          var streams = state.getStreams();
+          return Object.keys(streams).map(function (id) {
+            return subscribe(streams[id]);
+          });
         }
         return [Promise.resolve()];
       };
 
       // Handle success
       var onSubscribeToAll = function onSubscribeToAll() {
-        var pubSubData = Object.assign({}, state.getPubSub(), { publisher: publisher });
+        var pubSubData = _extends({}, state.getPubSub(), { publisher: publisher });
         triggerEvent('startCall', pubSubData);
         active = true;
         resolve(pubSubData);
@@ -291,7 +283,7 @@ var startCall = function startCall(publisherProperties) {
       var onError = function onError(reason) {
         message('Failed to subscribe to all existing streams: ' + reason);
         // We do not reject here in case we still successfully publish to the session
-        resolve(Object.assign({}, state.getPubSub(), { publisher: publisher }));
+        resolve(_extends({}, state.getPubSub(), { publisher: publisher }));
       };
 
       Promise.all(initialSubscriptions()).then(onSubscribeToAll).catch(onError);

--- a/sdk-wrapper-react-sample-app/src/ot-core/core.js
+++ b/sdk-wrapper-react-sample-app/src/ot-core/core.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _arguments = arguments;
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 /* global OT */
 /**
@@ -39,10 +41,10 @@ var dom = util.dom,
  * Individual Accelerator Packs
  */
 
-var textChat = undefined; // eslint-disable-line no-unused-vars
-var screenSharing = undefined; // eslint-disable-line no-unused-vars
-var annotation = undefined;
-var archiving = undefined; // eslint-disable-line no-unused-vars
+var textChat = void 0; // eslint-disable-line no-unused-vars
+var screenSharing = void 0; // eslint-disable-line no-unused-vars
+var annotation = void 0;
+var archiving = void 0; // eslint-disable-line no-unused-vars
 
 /**
  * Get access to an accelerator pack
@@ -99,9 +101,9 @@ var on = function on(event, callback) {
     message(event + ' is not a registered event.');
     // logAnalytics(logAction.on, logVariation.fail);
   } else {
-      eventCallbacks.add(callback);
-      // logAnalytics(logAction.on, logVariation.success);
-    }
+    eventCallbacks.add(callback);
+    // logAnalytics(logAction.on, logVariation.success);
+  }
 };
 
 /**
@@ -208,7 +210,7 @@ var createEventListeners = function createEventListeners(session, options) {
 
   on('startScreenSharing', function (publisher) {
     internalState.addPublisher('screen', publisher);
-    triggerEvent('startScreenShare', Object.assign({}, { publisher: publisher }, internalState.getPubSub()));
+    triggerEvent('startScreenShare', _extends({}, { publisher: publisher }, internalState.getPubSub()));
     if (internalAnnotation) {
       annotation.start(getSession()).then(function () {
         var absoluteParent = dom.query(path('annotation.absoluteParent.publisher', options));
@@ -240,15 +242,13 @@ var linkAnnotation = function linkAnnotation(pubSub, annotationContainer, extern
   });
 
   if (externalWindow) {
-    (function () {
-      // Add subscribers to the external window
-      var streams = internalState.getStreams();
-      var cameraStreams = Object.keys(streams).reduce(function (acc, streamId) {
-        var stream = streams[streamId];
-        return stream.videoType === 'camera' ? acc.concat(stream) : acc;
-      }, []);
-      cameraStreams.forEach(annotation.addSubscriberToExternalWindow);
-    })();
+    // Add subscribers to the external window
+    var streams = internalState.getStreams();
+    var cameraStreams = Object.keys(streams).reduce(function (acc, streamId) {
+      var stream = streams[streamId];
+      return stream.videoType === 'camera' ? acc.concat(stream) : acc;
+    }, []);
+    cameraStreams.forEach(annotation.addSubscriberToExternalWindow);
   }
 };
 
@@ -266,7 +266,7 @@ var initPackages = function initPackages() {
    * @returns {Object}
    */
   var optionalRequire = function optionalRequire(packageName, globalName) {
-    var result = undefined;
+    var result = void 0;
     /* eslint-disable global-require, import/no-extraneous-dependencies, import/no-unresolved */
     try {
       switch (packageName) {
@@ -368,7 +368,7 @@ var initPackages = function initPackages() {
       /* beautify ignore:start */
       case 'communication':
         {
-          return Object.assign({}, baseOptions, options.communication);
+          return _extends({}, baseOptions, options.communication);
         }
       case 'textChat':
         {
@@ -378,20 +378,20 @@ var initPackages = function initPackages() {
             sender: { alias: path('textChat.name', options) },
             alwaysOpen: path('textChat.alwaysOpen', options)
           };
-          return Object.assign({}, baseOptions, textChatOptions);
+          return _extends({}, baseOptions, textChatOptions);
         }
       case 'screenSharing':
         {
           var screenSharingContainer = { screenSharingContainer: streamContainers };
-          return Object.assign({}, baseOptions, screenSharingContainer, options.screenSharing);
+          return _extends({}, baseOptions, screenSharingContainer, options.screenSharing);
         }
       case 'annotation':
         {
-          return Object.assign({}, baseOptions, options.annotation);
+          return _extends({}, baseOptions, options.annotation);
         }
       case 'archiving':
         {
-          return Object.assign({}, baseOptions, options.archiving);
+          return _extends({}, baseOptions, options.archiving);
         }
       default:
         return {};
@@ -538,7 +538,7 @@ var signal = function signal(type, data, to) {
   return new Promise(function (resolve, reject) {
     logAnalytics(logAction.signal, logVariation.attempt);
     var session = getSession();
-    var signalObj = Object.assign({}, type ? { type: type } : null, data ? { data: JSON.stringify(data) } : null, to ? { to: to } : null // eslint-disable-line comma-dangle
+    var signalObj = _extends({}, type ? { type: type } : null, data ? { data: JSON.stringify(data) } : null, to ? { to: to } : null // eslint-disable-line comma-dangle
     );
     session.signal(signalObj, function (error) {
       if (error) {

--- a/sdk-wrapper-react-sample-app/src/ot-core/errors.js
+++ b/sdk-wrapper-react-sample-app/src/ot-core/errors.js
@@ -7,7 +7,6 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 /** Errors */
-
 var CoreError = function (_Error) {
   _inherits(CoreError, _Error);
 

--- a/sdk-wrapper-react-sample-app/src/ot-core/sdk-wrapper/errors.js
+++ b/sdk-wrapper-react-sample-app/src/ot-core/sdk-wrapper/errors.js
@@ -7,7 +7,6 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 /** Errors */
-
 var SDKError = function (_Error) {
   _inherits(SDKError, _Error);
 

--- a/sdk-wrapper-react-sample-app/src/ot-core/sdk-wrapper/sdkWrapper.js
+++ b/sdk-wrapper-react-sample-app/src/ot-core/sdk-wrapper/sdkWrapper.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -107,7 +107,6 @@ var OpenTokSDK = function () {
    * @param {String} credentials.sessionId
    * @param {String} credentials.token
    */
-
   function OpenTokSDK(credentials) {
     _classCallCheck(this, OpenTokSDK);
 

--- a/sdk-wrapper-react-sample-app/src/ot-core/sdk-wrapper/state.js
+++ b/sdk-wrapper-react-sample-app/src/ot-core/sdk-wrapper/state.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -184,7 +186,7 @@ var State = function () {
       var streams = this.streams,
           streamMap = this.streamMap;
 
-      return Object.assign({}, this.getPubSub(), { streams: streams, streamMap: streamMap });
+      return _extends({}, this.getPubSub(), { streams: streams, streamMap: streamMap });
     }
   }]);
 

--- a/sdk-wrapper-react-sample-app/src/ot-core/state.js
+++ b/sdk-wrapper-react-sample-app/src/ot-core/state.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 /**
  * Internal variables
  */
@@ -77,7 +79,7 @@ var getPubSub = function getPubSub() {
  * @return {Object}
  */
 var all = function all() {
-  return Object.assign({}, { streams: streams, streamMap: streamMap }, getPubSub());
+  return _extends({}, { streams: streams, streamMap: streamMap }, getPubSub());
 };
 
 /**

--- a/vanilla-js-sample-app/public/js/components/opentok-acc-core.js
+++ b/vanilla-js-sample-app/public/js/components/opentok-acc-core.js
@@ -3,7 +3,7 @@ function _classCallCheck(n,e){if(!(n instanceof e))throw new TypeError("Cannot c
 },{}],2:[function(require,module,exports){
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 /* global OT */
 
@@ -84,7 +84,7 @@ var ableToJoin = function ableToJoin() {
 var createPublisher = function createPublisher(publisherProperties) {
   return new Promise(function (resolve, reject) {
     // TODO: Handle adding 'name' option to props
-    var props = Object.assign({}, callProperties, publisherProperties);
+    var props = _extends({}, callProperties, publisherProperties);
     // TODO: Figure out how to handle common vs package-specific options
     // ^^^ This may already be available through package options
     var container = dom.element(streamContainers('publisher', 'camera'));
@@ -144,25 +144,23 @@ var subscribe = function subscribe(stream) {
       // Are we already subscribing to the stream?
       resolve();
     } else {
-      (function () {
-        // No videoType indicates SIP https://tokbox.com/developer/guides/sip/
-        var type = pathOr('sip', 'videoType', stream);
-        var connectionData = JSON.parse(path(['connection', 'data'], stream) || null);
-        var container = dom.query(streamContainers('subscriber', type, connectionData, streamId));
-        var options = type === 'camera' ? callProperties : screenProperties;
-        var subscriber = session.subscribe(stream, container, options, function (error) {
-          if (error) {
-            logAnalytics(logAction.subscribe, logVariation.fail);
-            reject(error);
-          } else {
-            state.addSubscriber(subscriber);
-            triggerEvent('subscribeTo' + properCase(type), Object.assign({}, { subscriber: subscriber }, state.all()));
-            type === 'screen' && triggerEvent('startViewingSharedScreen', subscriber); // Legacy event
-            logAnalytics(logAction.subscribe, logVariation.success);
-            resolve();
-          }
-        });
-      })();
+      // No videoType indicates SIP https://tokbox.com/developer/guides/sip/
+      var type = pathOr('sip', 'videoType', stream);
+      var connectionData = JSON.parse(path(['connection', 'data'], stream) || null);
+      var container = dom.query(streamContainers('subscriber', type, connectionData, streamId));
+      var options = type === 'camera' ? callProperties : screenProperties;
+      var subscriber = session.subscribe(stream, container, options, function (error) {
+        if (error) {
+          logAnalytics(logAction.subscribe, logVariation.fail);
+          reject(error);
+        } else {
+          state.addSubscriber(subscriber);
+          triggerEvent('subscribeTo' + properCase(type), _extends({}, { subscriber: subscriber }, state.all()));
+          type === 'screen' && triggerEvent('startViewingSharedScreen', subscriber); // Legacy event
+          logAnalytics(logAction.subscribe, logVariation.success);
+          resolve();
+        }
+      });
     }
   });
 };
@@ -201,7 +199,7 @@ var validateOptions = function validateOptions(options) {
   connectionLimit = options.connectionLimit || null;
   autoSubscribe = options.hasOwnProperty('autoSubscribe') ? options.autoSubscribe : true;
 
-  screenProperties = options.screenProperties || Object.assign({}, defaultCallProperties, { videoSource: 'window' });
+  screenProperties = options.screenProperties || _extends({}, defaultCallProperties, { videoSource: 'window' });
 };
 
 /**
@@ -268,23 +266,17 @@ var startCall = function startCall(publisherProperties) {
       // Get an array of initial subscription promises
       var initialSubscriptions = function initialSubscriptions() {
         if (autoSubscribe) {
-          var _ret2 = function () {
-            var streams = state.getStreams();
-            return {
-              v: Object.keys(streams).map(function (id) {
-                return subscribe(streams[id]);
-              })
-            };
-          }();
-
-          if ((typeof _ret2 === 'undefined' ? 'undefined' : _typeof(_ret2)) === "object") return _ret2.v;
+          var streams = state.getStreams();
+          return Object.keys(streams).map(function (id) {
+            return subscribe(streams[id]);
+          });
         }
         return [Promise.resolve()];
       };
 
       // Handle success
       var onSubscribeToAll = function onSubscribeToAll() {
-        var pubSubData = Object.assign({}, state.getPubSub(), { publisher: publisher });
+        var pubSubData = _extends({}, state.getPubSub(), { publisher: publisher });
         triggerEvent('startCall', pubSubData);
         active = true;
         resolve(pubSubData);
@@ -294,7 +286,7 @@ var startCall = function startCall(publisherProperties) {
       var onError = function onError(reason) {
         message('Failed to subscribe to all existing streams: ' + reason);
         // We do not reject here in case we still successfully publish to the session
-        resolve(Object.assign({}, state.getPubSub(), { publisher: publisher }));
+        resolve(_extends({}, state.getPubSub(), { publisher: publisher }));
       };
 
       Promise.all(initialSubscriptions()).then(onSubscribeToAll).catch(onError);
@@ -387,6 +379,8 @@ module.exports = {
 },{"./errors":4,"./logging":6,"./state":10,"./util":11}],3:[function(require,module,exports){
 (function (global){
 'use strict';
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 var _arguments = arguments;
 
@@ -596,7 +590,7 @@ var createEventListeners = function createEventListeners(session, options) {
 
   on('startScreenSharing', function (publisher) {
     internalState.addPublisher('screen', publisher);
-    triggerEvent('startScreenShare', Object.assign({}, { publisher: publisher }, internalState.getPubSub()));
+    triggerEvent('startScreenShare', _extends({}, { publisher: publisher }, internalState.getPubSub()));
     if (internalAnnotation) {
       annotation.start(getSession()).then(function () {
         var absoluteParent = dom.query(path('annotation.absoluteParent.publisher', options));
@@ -628,15 +622,13 @@ var linkAnnotation = function linkAnnotation(pubSub, annotationContainer, extern
   });
 
   if (externalWindow) {
-    (function () {
-      // Add subscribers to the external window
-      var streams = internalState.getStreams();
-      var cameraStreams = Object.keys(streams).reduce(function (acc, streamId) {
-        var stream = streams[streamId];
-        return stream.videoType === 'camera' ? acc.concat(stream) : acc;
-      }, []);
-      cameraStreams.forEach(annotation.addSubscriberToExternalWindow);
-    })();
+    // Add subscribers to the external window
+    var streams = internalState.getStreams();
+    var cameraStreams = Object.keys(streams).reduce(function (acc, streamId) {
+      var stream = streams[streamId];
+      return stream.videoType === 'camera' ? acc.concat(stream) : acc;
+    }, []);
+    cameraStreams.forEach(annotation.addSubscriberToExternalWindow);
   }
 };
 
@@ -756,7 +748,7 @@ var initPackages = function initPackages() {
       /* beautify ignore:start */
       case 'communication':
         {
-          return Object.assign({}, baseOptions, options.communication);
+          return _extends({}, baseOptions, options.communication);
         }
       case 'textChat':
         {
@@ -766,20 +758,20 @@ var initPackages = function initPackages() {
             sender: { alias: path('textChat.name', options) },
             alwaysOpen: path('textChat.alwaysOpen', options)
           };
-          return Object.assign({}, baseOptions, textChatOptions);
+          return _extends({}, baseOptions, textChatOptions);
         }
       case 'screenSharing':
         {
           var screenSharingContainer = { screenSharingContainer: streamContainers };
-          return Object.assign({}, baseOptions, screenSharingContainer, options.screenSharing);
+          return _extends({}, baseOptions, screenSharingContainer, options.screenSharing);
         }
       case 'annotation':
         {
-          return Object.assign({}, baseOptions, options.annotation);
+          return _extends({}, baseOptions, options.annotation);
         }
       case 'archiving':
         {
-          return Object.assign({}, baseOptions, options.archiving);
+          return _extends({}, baseOptions, options.archiving);
         }
       default:
         return {};
@@ -926,7 +918,7 @@ var signal = function signal(type, data, to) {
   return new Promise(function (resolve, reject) {
     logAnalytics(logAction.signal, logVariation.attempt);
     var session = getSession();
-    var signalObj = Object.assign({}, type ? { type: type } : null, data ? { data: JSON.stringify(data) } : null, to ? { to: to } : null // eslint-disable-line comma-dangle
+    var signalObj = _extends({}, type ? { type: type } : null, data ? { data: JSON.stringify(data) } : null, to ? { to: to } : null // eslint-disable-line comma-dangle
     );
     session.signal(signalObj, function (error) {
       if (error) {
@@ -1705,6 +1697,8 @@ module.exports = OpenTokSDK;
 },{"./errors":7,"./state":9}],9:[function(require,module,exports){
 "use strict";
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -1889,7 +1883,7 @@ var State = function () {
       var streams = this.streams,
           streamMap = this.streamMap;
 
-      return Object.assign({}, this.getPubSub(), { streams: streams, streamMap: streamMap });
+      return _extends({}, this.getPubSub(), { streams: streams, streamMap: streamMap });
     }
   }]);
 
@@ -1900,6 +1894,8 @@ module.exports = State;
 
 },{}],10:[function(require,module,exports){
 'use strict';
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 /**
  * Internal variables
@@ -1978,7 +1974,7 @@ var getPubSub = function getPubSub() {
  * @return {Object}
  */
 var all = function all() {
-  return Object.assign({}, { streams: streams, streamMap: streamMap }, getPubSub());
+  return _extends({}, { streams: streams, streamMap: streamMap }, getPubSub());
 };
 
 /**


### PR DESCRIPTION
This PR adds babel-transform-object-assign to handle the Object.assign that is not compatible with IE11.