### PR TITLE
[OTS-1145] Bugfix: try catch for when connectionData not JSON

### DIFF
--- a/src/communication.js
+++ b/src/communication.js
@@ -109,6 +109,7 @@ const publish = publisherProperties =>
  */
 const subscribe = stream =>
   new Promise((resolve, reject) => {
+    let connectionData;
     logAnalytics(logAction.subscribe, logVariation.attempt);
     const streamMap = state.getStreamMap();
     const { streamId } = stream;
@@ -118,7 +119,11 @@ const subscribe = stream =>
     } else {
       // No videoType indicates SIP https://tokbox.com/developer/guides/sip/
       const type = pathOr('sip', 'videoType', stream);
-      const connectionData = JSON.parse(path(['connection', 'data'], stream) || null);
+      try {
+        connectionData = JSON.parse(path(['connection', 'data'], stream) || null);
+      } catch (e) {
+        connectionData = path(['connection', 'data'], stream);
+      }
       const container = dom.query(streamContainers('subscriber', type, connectionData, streamId));
       const options = type === 'camera' || type === 'sip' ? callProperties : screenProperties;
       const subscriber = session.subscribe(stream, container, options, (error) => {


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts. Confirmation: ____

#### This fixes issue #___.

## What's in this pull request?

OTS-1145 Accelerator core assumes connection data is json, causes fatal error when not. (No streams can be received)
