### PR TITLE
Remove polyfill from node build. Include only in browser build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,16 @@
   "main": "dist/core.js",
   "scripts": {
     "build:node": "babel -d ./dist/ ./src/",
-    "build:browser": "browserify src/core.js -o browser/opentok-acc-core.js -t [ babelify --presets [ es2015 ] ] --im",
+    "build:browser-polyfill": "(echo \"require('babel-polyfill');\\n\"; cat src/core.js) > src/browser-temp.js",
+    "build:browser-browserify": "browserify src/browser-temp.js -o browser/opentok-acc-core.js -t [ babelify --presets [ es2015 ] ] --im",
+    "build:browser": "npm run build:browser-polyfill && npm run build:browser-browserify && rm src/browser-temp.js",
     "build": "npm run build:node && npm run build:browser",
     "test": "karma start"
   },
   "keywords": [
     "opentok",
+    "accelerator",
+    "core",
     "opentok-acc-pack",
     "webrtc",
     "communication",
@@ -21,6 +25,7 @@
   "author": "adrice727@gmail.com",
   "license": "MIT",
   "devDependencies": {
+    "babel-polyfill": "*",
     "babel-preset-es2015": "^6.16.0",
     "babelify": "^7.3.0",
     "browserify": "^13.1.1",
@@ -31,7 +36,6 @@
     "eslint-plugin-react": "^6.9.0"
   },
   "dependencies": {
-    "babel-polyfill": "*",
     "opentok-solutions-logging": "^1.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-accelerator-core",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Opentok Accelerator Core",
   "repository": "https://github.com/opentok/accelerator-core-js",
   "main": "dist/core.js",

--- a/src/core.js
+++ b/src/core.js
@@ -2,7 +2,6 @@
 /**
  * Dependencies
  */
-require('babel-polyfill');
 const util = require('./util');
 const internalState = require('./state');
 const accPackEvents = require('./events');


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts. Confirmation: ____


`babel-polyfill` should not be included in the `node` build.  If it's used in a project that also includes the polyfill, `babel` will throw an error at compile time.  Users who wish to polyfill for IE or older browsers can include the polyfill themselves.  The `browser` version will continue to use the polyfill since it's assumed that users consuming this version are not using `webpack/browserify`.