### PR TITLE
SDK Listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-accelerator-core",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Opentok Accelerator Core",
   "repository": "https://github.com/opentok/accelerator-core-js",
   "main": "dist/core.js",

--- a/src/sdk-wrapper/sdkWrapper.js
+++ b/src/sdk-wrapper/sdkWrapper.js
@@ -95,7 +95,6 @@ class OpenTokSDK {
     this.credentials = validateCredentials(credentials);
     stateMap.set(this, new State());
     this.session = OT.initSession(credentials.apiKey, credentials.sessionId);
-    this.setInternalListeners();
   }
 
   /**
@@ -294,6 +293,7 @@ class OpenTokSDK {
    */
   connect(eventListeners) {
     this.off();
+    this.setInternalListeners();
     eventListeners && this.on(eventListeners);
     return new Promise((resolve, reject) => {
       const { token } = this.credentials;


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts. Confirmation: ____

#### This fixes issue #___.

`sdkWrapper` state was not being updated because the internal event listeners were not being called.

## What's in this pull request?

Call `setInternalListeners` in the connect method, after removing any _left over_  listeners with`off()`.
