### PR TITLE
Accept Name for Core Instance

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,6 +1,20 @@
 # OpenTok Accelerator Core API Methods
 
+### `@constructor`
 
+**Parameters**
+
+**options**: `Object`
+
+ - **options.credentials**: `Object` (required)
+
+ - **options.name**: `String` A name for your core instance
+
+ - **options.packages**: `Array`
+
+ - **options.streamContainers**: `Function`
+
+ - **options.controlsContainer**: `String`
 
 * * *
 
@@ -98,24 +112,6 @@
 **stream**: `Object` An OpenTok stream object
 
 **Returns**: `Array` An array of subscriber object
-
-
-### `init(options)`
-
-*Initialize accelerator core*
-
-**Parameters**
-
-**options**: `Object` Initialize the accelerator pack
-
- - **options.credentials**: `Object`
-
- - **options.packages**: `Array`
-
- - **options.streamContainers**: `Function`
-
- - **options.controlsContainer**: `String`
-
 
 
 ### `off(event, callback)`

--- a/src/core.js
+++ b/src/core.js
@@ -45,6 +45,7 @@ class AccCore {
     }
     const { credentials } = options;
     validateCredentials(options.credentials);
+    this.name = options.name;
 
     // Init analytics
     this.analytics = new Analytics(window.location.origin, credentials.sessionId, null, credentials.apiKey);


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts. Confirmation: ____

## What's in this pull request?

1. Core constructor accepts a `name` parameter which may be useful when multiple instances of core are being using a single application.

2. Update API doc to remove reference to `init()` and add info regarding the `constructor`. 
