### PR TITLE
OPENTOK 34167 - Add subscribeOnly option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ The `streamContainers` property is a function that specifies which DOM element s
 
 ```javascript
   /**
-   * @param {String} pubSub - 'publisher' or 'subscriber'
-   * @param {String} type - 'camera' or 'screen'
-   * @param {*} data - Parsed stream connection data (subscriber only)
-   * @param {Object} stream - The new stream (subscriber only)
+ * @param {String} pubSub - 'publisher' or 'subscriber'
+ * @param {String} type - 'camera' or 'screen'
+ * @param {*} data - Parsed stream connection data (subscriber only)
+ * @param {Object} stream - The new stream (subscriber only)
    */
   streamContainers(pubSub, type, data, stream){
     return {
@@ -91,11 +91,17 @@ The `streamContainers` property is a function that specifies which DOM element s
   controlsContainer: '#videoControls',
 ```
 #### Communication Options
-The `communication` properties relate to the multi-party communication provided by `Core`.  `autoSubscribe` dictates whether or not `Core` automatically subscribes to new streams and is set to `true` by default.  `connectionLimit` limits the number of parties that may publish/subscribe to the session.  `callProperties` allows for [customization](https://www.tokbox.com/developer/guides/customize-ui/js/) of the UI.
+The `communication` properties relate to the multi-party communication provided by `Core`:
+
+ * `autoSubscribe` dictates whether or not `Core` automatically subscribes to new streams and is set to `true` by default.
+ * `subscribeOnly`, which is set to `false` by default, allows users to join an OpenTok session and subscribe to streams without publishing any audio or video.
+ * `connectionLimit` limits the number of parties that may publish/subscribe to the session.
+ * `callProperties` allows for [customization](https://www.tokbox.com/developer/guides/customize-ui/js/) of the UI.
 
 ```javascript
   communication: {
   autoSubscribe: true,
+  subscribeOnly: false,
   connectionLimit: null,
     callProperties: myCallProperties,
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-accelerator-core",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "Opentok Accelerator Core",
   "repository": "https://github.com/opentok/accelerator-core-js",
   "main": "dist/core.js",

--- a/src/communication.js
+++ b/src/communication.js
@@ -174,7 +174,7 @@ class Communication {
     const { analytics, session, state } = this;
     return new Promise((resolve) => {
       analytics.log(logAction.unsubscribe, logVariation.attempt);
-      const type = path('stream.videoType', subscriber);
+      const type = pathOr('sip', 'stream.videoType', subscriber);
       state.removeSubscriber(type, subscriber);
       session.unsubscribe(subscriber);
       analytics.log(logAction.unsubscribe, logVariation.success);

--- a/src/communication.js
+++ b/src/communication.js
@@ -41,7 +41,7 @@ class Communication {
     this.callProperties = Object.assign({}, defaultCallProperties, callProperties);
     this.connectionLimit = options.connectionLimit || null;
     this.autoSubscribe = options.hasOwnProperty('autoSubscribe') ? autoSubscribe : true;
-    this.subscribeOnly = options.hasOwnProperty('subscribeOnly') ? subscribeOnly : true;
+    this.subscribeOnly = options.hasOwnProperty('subscribeOnly') ? subscribeOnly : false;
     this.screenProperties = Object.assign({}, defaultCallProperties, { videoSource: 'window' }, screenProperties);
   }
     /**

--- a/src/communication.js
+++ b/src/communication.js
@@ -32,7 +32,7 @@ class Communication {
         throw new CoreError(`${option} is a required option.`, 'invalidParameters');
       }
     });
-    const { callProperties, screenProperties, autoSubscribe } = options;
+    const { callProperties, screenProperties, autoSubscribe, subscribeOnly } = options;
     this.active = false;
     this.core = options.core;
     this.state = options.state;
@@ -41,6 +41,7 @@ class Communication {
     this.callProperties = Object.assign({}, defaultCallProperties, callProperties);
     this.connectionLimit = options.connectionLimit || null;
     this.autoSubscribe = options.hasOwnProperty('autoSubscribe') ? autoSubscribe : true;
+    this.subscribeOnly = options.hasOwnProperty('subscribeOnly') ? subscribeOnly : true;
     this.screenProperties = Object.assign({}, defaultCallProperties, { videoSource: 'window' }, screenProperties);
   }
     /**
@@ -90,7 +91,16 @@ class Communication {
    * @returns {Promise} <resolve: empty, reject: Error>
    */
   publish = (publisherProperties) => {
-    const { analytics, state, createPublisher, session, triggerEvent } = this;
+    const { analytics, state, createPublisher, session, triggerEvent, subscribeOnly } = this;
+
+    /**
+     * For subscriber tokens or cases where we just don't want to be seen or heard.
+     */
+    if (subscribeOnly) {
+      message('Instance is configured with subscribeOnly set to true. Cannot publish to session');
+      return Promise.resolve();
+    }
+
     return new Promise((resolve, reject) => {
       const onPublish = publisher => (error) => {
         if (error) {


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts. Confirmation: ____

#### This fixes issue #___.

## What's in this pull request?

Add a `subscribeOnly` options to the communications options hash to allow for `subscriber` tokens or use cases where one only wants to subscribe to a session.
