### PR TITLE
No longer stringifying data in signals

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -587,7 +587,7 @@ class AccCore {
       const session = getSession();
       const signalObj = Object.assign({},
         type ? { type } : null,
-        data ? { data: JSON.stringify(data) } : null,
+        data ? { data } : null,
         to ? { to } : null // eslint-disable-line comma-dangle
       );
       session.signal(signalObj, (error) => {


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts. Confirmation: ____

#### This fixes issue #76.

## What's in this pull request?

Previously, we were sending data in signaling as: `data: JSON.stringify(data)`, but data allows an object to be sent.  Modified to simply send the object without the stringify.
