### PR TITLE
Added improved error messages when incorrectly unsubscribing from destroyed stream

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -33,22 +33,22 @@ class State {
  * Internal methods
  */
 
-/**
- * Returns the count of current publishers and subscribers by type
- * @retuns {Object}
- *    {
- *      publishers: {
- *        camera: 1,
- *        screen: 1,
- *        total: 2
- *      },
- *      subscribers: {
- *        camera: 3,
- *        screen: 1,
- *        total: 4
- *      }
- *   }
- */
+  /**
+   * Returns the count of current publishers and subscribers by type
+   * @retuns {Object}
+   *    {
+   *      publishers: {
+   *        camera: 1,
+   *        screen: 1,
+   *        total: 2
+   *      },
+   *      subscribers: {
+   *        camera: 3,
+   *        screen: 1,
+   *        total: 4
+   *      }
+   *   }
+   */
   pubSubCount = () => {
     const { publishers, subscribers } = this;
     /* eslint-disable no-param-reassign */
@@ -178,8 +178,12 @@ class State {
   removePublisher = (type, publisher) => {
     const { streamMap, publishers } = this;
     const id = publisher.id || streamMap[publisher.streamId];
-    delete publishers[type][id];
-    delete streamMap[publisher.streamId];
+    if (id) {
+      delete publishers[type][id];
+      delete streamMap[publisher.streamId];
+    } else {
+      throw 'Publisher no longer exists. It may have been previously destroyed.'
+    }
   }
 
   /**
@@ -214,8 +218,12 @@ class State {
   removeSubscriber = (type, subscriber) => {
     const { subscribers, streamMap } = this;
     const id = subscriber.id || streamMap[subscriber.streamId];
-    delete subscribers[type][id];
-    delete streamMap[subscriber.streamId];
+    if (id) {
+      delete subscribers[type][id];
+      delete streamMap[subscriber.streamId];
+    } else {
+      throw 'Subscriber no longer exists. It may have been previously destroyed.'
+    }
   }
 
   /**


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts. Confirmation: ____

#### This fixes issue #55.

## What's in this pull request?

No change in behavior, but if an attempt is made to unsubscribe from a previously destroyed stream, the error message will now present the actual problem rather than reporting an issue with null or undefined references in state.
