### PR TITLE
Added OTPublisher publisherCreatedCallback to properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The `communication` properties relate to the multi-party communication provided 
 - `autoSubscribe` dictates whether or not `Core` automatically subscribes to new streams and is set to `true` by default.
 - `subscribeOnly`, which is set to `false` by default, allows users to join an OpenTok session and subscribe to streams without publishing any audio or video.
 - `connectionLimit` limits the number of parties that may publish/subscribe to the session.
+- `publisherCreatedCallback` is a callback `(error, publisher) => {...}` used to subscribe to events on publisher before we try to publish to the session. e.g. register to `accessDialogOpened` event.
 - `callProperties` allows for [customization](https://www.tokbox.com/developer/guides/customize-ui/js/) of the UI.
 
 ```javascript
@@ -118,6 +119,7 @@ The `communication` properties relate to the multi-party communication provided 
     autoSubscribe: true,
     subscribeOnly: false,
     connectionLimit: null,
+    publisherCreatedCallback: null,
     callProperties: myCallProperties,
   },
 ```

--- a/src/communication.js
+++ b/src/communication.js
@@ -41,6 +41,7 @@ class Communication {
     this.callProperties = Object.assign({}, defaultCallProperties, callProperties);
     this.connectionLimit = options.connectionLimit || null;
     this.autoSubscribe = options.hasOwnProperty('autoSubscribe') ? autoSubscribe : true;
+    this.publisherCreatedCallback = options.publisherCreatedCallback || null,
     this.subscribeOnly = options.hasOwnProperty('subscribeOnly') ? subscribeOnly : false;
     this.screenProperties = Object.assign({}, defaultCallProperties, { videoSource: 'window' }, screenProperties);
   }
@@ -72,7 +73,7 @@ class Communication {
    * @returns {Promise} <resolve: Object, reject: Error>
    */
   createPublisher = (publisherProperties) => {
-    const { callProperties, streamContainers } = this;
+    const { callProperties, publisherCreatedCallback, streamContainers } = this;
     return new Promise((resolve, reject) => {
       // TODO: Handle adding 'name' option to props
       const props = Object.assign({}, callProperties, publisherProperties);
@@ -80,6 +81,12 @@ class Communication {
       // ^^^ This may already be available through package options
       const container = dom.element(streamContainers('publisher', 'camera'));
       const publisher = OT.initPublisher(container, props, (error) => {
+
+        // Allow the user to register to events on the newly created publisher
+        // e.g.: accessDialogOpened
+        if(publisherCreatedCallback) {
+          publisherCreatedCallback(error, publisher)
+        }
         error ? reject(error) : resolve(publisher);
       });
     });


### PR DESCRIPTION
## What's in this pull request?

This will allow a user to register to events on publisher before it actually tries to publish to the session

e.g.: accessDialogOpened event

