### PR TITLE
Fix publisher id undefined after occuring after 2.27.6

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -177,7 +177,7 @@ class State {
 
     publisherMap[publisher] = publisher.id;
     streamMap[publisher.streamId] = publisher.id;
-    publishers.publishers[type][publisher.id] = publisher;
+    publishers[type][publisher.id] = publisher;
   }
 
   /**

--- a/src/state.js
+++ b/src/state.js
@@ -22,6 +22,9 @@ class State {
     // Map stream ids to subscriber/publisher ids
     this.streamMap = {};
 
+    // Map publisher to publisher ids
+    this.publisherMap = {};
+
     // The OpenTok session
     this.session = null;
 
@@ -170,8 +173,11 @@ class State {
    * @param {Object} publisher - The OpenTok publisher object
    */
   addPublisher = (type, publisher) => {
-    this.streamMap[publisher.streamId] = publisher.id;
-    this.publishers[type][publisher.id] = publisher;
+    const { streamMap, publishers, publisherMap } = this;
+
+    publisherMap[publisher] = publisher.id;
+    streamMap[publisher.streamId] = publisher.id;
+    publishers.publishers[type][publisher.id] = publisher;
   }
 
   /**
@@ -180,8 +186,8 @@ class State {
    * @param {Object} publisher - The OpenTok publisher object
    */
   removePublisher = (type, publisher) => {
-    const { streamMap, publishers } = this;
-    const id = publisher.id || streamMap[publisher.streamId];
+    const { streamMap, publisherMap } = this;
+    const id = publisher.id || publisherMap[publisher];
     if (id == null) {
       throw 'Publisher no longer exists. It may have been previously destroyed.'
     }

--- a/src/state.js
+++ b/src/state.js
@@ -186,13 +186,18 @@ class State {
    * @param {Object} publisher - The OpenTok publisher object
    */
   removePublisher = (type, publisher) => {
-    const { streamMap, publisherMap } = this;
+    const { streamMap, publishers, publisherMap } = this;
     const id = publisher.id || publisherMap[publisher];
     if (id == null) {
       throw 'Publisher no longer exists. It may have been previously destroyed.'
     }
     delete publishers[type][id];
-    delete streamMap[publisher.streamId];
+    delete publisherMap[publisher];
+    for (const [streamId, pubId] of Object.entries(streamMap)) {
+      if (pubId === id) {
+          delete streamMap[streamId];
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs: Should be
- [x] I have resolved any merge conflicts. Confirmation: Yes


## What's in this pull request?

After release 2.27.6, once you unpublish a publisher, the publisher ID and stream ID are no longer present. This causes an issue in the code as we use the publisher Id to clean-up after removing publisher.
As publisher Id is null, an error is always thrown when removePublisher method as shared below ('Publisher no longer exists. It may have been previously destroyed')

  ```
removePublisher = (type, publisher) => {
    const { streamMap, publishers } = this;
    const id = publisher.id || streamMap[publisher.streamId];
    if (id == null) {
      throw 'Publisher no longer exists. It may have been previously destroyed.'
    }
    delete publishers[type][id];
    delete streamMap[publisher.streamId];
  }
```

As a workaround, I just have added a simple publisher-publisher-id mapping to prevent this issue.


>...
